### PR TITLE
Refactor MVP to use centralized prompt constants

### DIFF
--- a/backend/mvp/constants.py
+++ b/backend/mvp/constants.py
@@ -1,8 +1,16 @@
 # -*- coding: utf-8 -*-
 """Minimal prompt constants for the orchestrator modules."""
 
-# Planning prompt
+# Planning & classification prompts
 PLANNER_PROMPT = "PLAN: {q}\n{hints}"
+CLASSIFY_SCHEMA_HINT = '{ "kind":"Atomic|Hybrid|Composite","score":0..1,"rationale":"...","cues":{...} }'
+CLASSIFY_QUERY_PROMPT = (
+    "SYSTEM: CLASSIFY\n"
+    "Return ONLY JSON.\n"
+    "Schema: {schema}\n"
+    "Task: Classify scope/complexity.\n"
+    "QUERY: {query}"
+)
 
 # Node-related prompts
 ANALYSIS_NODE_PROMPT = "Analyze the query: {query}"
@@ -30,3 +38,9 @@ TEMPLATE_CONTRACTS = {}
 
 # LLM judge prompt placeholder
 LLM_JUDGE_PROMPT = "Judge the text:\n{text}\nContract: {contract}"
+
+# Demo defaults
+DEFAULT_DEMO_QUERY = (
+    "Design a secure CRUD API. Provide architecture, data model, and risks. "
+    "Compare 2 frameworks and give a migration plan."
+)

--- a/backend/mvp/demo.py
+++ b/backend/mvp/demo.py
@@ -9,10 +9,18 @@ import json
 import os
 from pathlib import Path
 
-from config import OrchestratorConfig
-from execution import Orchestrator
-from memory import MemoryStore
-from solver import build_default_solver_and_planner
+try:
+    from .constants import DEFAULT_DEMO_QUERY
+    from .config import OrchestratorConfig
+    from .execution import Orchestrator
+    from .memory import MemoryStore
+    from .solver import build_default_solver_and_planner
+except ImportError:  # pragma: no cover - fallback for script usage
+    from constants import DEFAULT_DEMO_QUERY  # type: ignore
+    from config import OrchestratorConfig  # type: ignore
+    from execution import Orchestrator  # type: ignore
+    from memory import MemoryStore  # type: ignore
+    from solver import build_default_solver_and_planner  # type: ignore
 
 
 async def main_async() -> None:
@@ -25,10 +33,7 @@ async def main_async() -> None:
     p.add_argument("--mock", action="store_true", help="Force mock planner/solver")
     args = p.parse_args()
 
-    query = " ".join(args.query).strip() or (
-        "Design a secure CRUD API. Provide architecture, data model, and risks. "
-        "Compare 2 frameworks and give a migration plan."
-    )
+    query = " ".join(args.query).strip() or DEFAULT_DEMO_QUERY
 
     solver = planner = None
     if not args.mock:

--- a/backend/mvp/execution.py
+++ b/backend/mvp/execution.py
@@ -11,47 +11,90 @@ import uuid
 from dataclasses import asdict
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
-from config import (
-    FORECAST_ALPHA,
-    FORECAST_BUFFER,
-    FORECAST_DEFAULT_TOKENS,
-    OrchestratorConfig,
-)
-from constants import (
-    CLAIMS_EXTRACT_PROMPT,
-    COHESION_APPLY_PROMPT,
-    COHESION_PROMPT,
-    DENSE_FINAL_ANSWER_PROMPT,
-    NODE_APPLY_PROMPT,
-    NODE_RECOMMEND_PROMPT,
-)
-from judges import JUDGES
-from memory import MemoryStore
-from planning import classify_query_llm, make_plan
-from bb_types import (
-    Artifact,
-    BlackBoxSolver,
-    Contract,
-    Critique,
-    Node,
-    Patch,
-    Plan,
-    QAResult,
-)
-from utils import (
-    AUDIT,
-    GLOBAL_LIMITER,
-    LOG,
-    approx_tokens,
-    apply_patches,
-    clip_chars,
-    dataclass_to_json,
-    first_json_object,
-    fmt,
-    run_tests,
-    safe_json_loads,
-    sanitize_text,
-)
+try:
+    from .config import (
+        FORECAST_ALPHA,
+        FORECAST_BUFFER,
+        FORECAST_DEFAULT_TOKENS,
+        OrchestratorConfig,
+    )
+    from .constants import (
+        CLAIMS_EXTRACT_PROMPT,
+        COHESION_APPLY_PROMPT,
+        COHESION_PROMPT,
+        DENSE_FINAL_ANSWER_PROMPT,
+        NODE_APPLY_PROMPT,
+        NODE_RECOMMEND_PROMPT,
+    )
+    from .judges import JUDGES
+    from .memory import MemoryStore
+    from .planning import classify_query_llm, make_plan
+    from .bb_types import (
+        Artifact,
+        BlackBoxSolver,
+        Contract,
+        Critique,
+        Node,
+        Patch,
+        Plan,
+        QAResult,
+    )
+    from .utils import (
+        AUDIT,
+        GLOBAL_LIMITER,
+        LOG,
+        approx_tokens,
+        apply_patches,
+        clip_chars,
+        dataclass_to_json,
+        first_json_object,
+        fmt,
+        run_tests,
+        safe_json_loads,
+        sanitize_text,
+    )
+except ImportError:  # pragma: no cover - fallback for script usage
+    from config import (
+        FORECAST_ALPHA,
+        FORECAST_BUFFER,
+        FORECAST_DEFAULT_TOKENS,
+        OrchestratorConfig,
+    )  # type: ignore
+    from constants import (
+        CLAIMS_EXTRACT_PROMPT,
+        COHESION_APPLY_PROMPT,
+        COHESION_PROMPT,
+        DENSE_FINAL_ANSWER_PROMPT,
+        NODE_APPLY_PROMPT,
+        NODE_RECOMMEND_PROMPT,
+    )  # type: ignore
+    from judges import JUDGES  # type: ignore
+    from memory import MemoryStore  # type: ignore
+    from planning import classify_query_llm, make_plan  # type: ignore
+    from bb_types import (
+        Artifact,
+        BlackBoxSolver,
+        Contract,
+        Critique,
+        Node,
+        Patch,
+        Plan,
+        QAResult,
+    )  # type: ignore
+    from utils import (
+        AUDIT,
+        GLOBAL_LIMITER,
+        LOG,
+        approx_tokens,
+        apply_patches,
+        clip_chars,
+        dataclass_to_json,
+        first_json_object,
+        fmt,
+        run_tests,
+        safe_json_loads,
+        sanitize_text,
+    )  # type: ignore
 
 
 class Orchestrator:

--- a/backend/mvp/judges.py
+++ b/backend/mvp/judges.py
@@ -7,8 +7,12 @@ import re
 from dataclasses import asdict
 from typing import Dict, List
 
-from bb_types import Contract, Critique, Judge
-from utils import ensure_header
+try:
+    from .bb_types import Contract, Critique, Judge
+    from .utils import ensure_header
+except ImportError:  # pragma: no cover - fallback for script usage
+    from bb_types import Contract, Critique, Judge  # type: ignore
+    from utils import ensure_header  # type: ignore
 
 
 class JudgeRegistry:

--- a/backend/mvp/memory.py
+++ b/backend/mvp/memory.py
@@ -10,13 +10,22 @@ import threading
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
-from config import (
-    CLUSTER_LINK_WEIGHT,
-    CLUSTER_MIN_SIM,
-    KLINE_EMBED_DIM,
-    KLINE_MAX_ENTRIES,
-)
-from utils import AUDIT, cosine, dequantize, hash_embed, quantize
+try:
+    from .config import (
+        CLUSTER_LINK_WEIGHT,
+        CLUSTER_MIN_SIM,
+        KLINE_EMBED_DIM,
+        KLINE_MAX_ENTRIES,
+    )
+    from .utils import AUDIT, cosine, dequantize, hash_embed, quantize
+except ImportError:  # pragma: no cover - fallback for script usage
+    from config import (
+        CLUSTER_LINK_WEIGHT,
+        CLUSTER_MIN_SIM,
+        KLINE_EMBED_DIM,
+        KLINE_MAX_ENTRIES,
+    )  # type: ignore
+    from utils import AUDIT, cosine, dequantize, hash_embed, quantize  # type: ignore
 
 
 class MemoryStore:

--- a/backend/mvp/planning.py
+++ b/backend/mvp/planning.py
@@ -7,9 +7,22 @@ import re
 from dataclasses import dataclass
 from typing import Any, Dict, List, Mapping, Optional
 
-from constants import PLANNER_PROMPT  # prompt strings live in constants.py
-from bb_types import Classification, Contract, Node, Plan, TestSpec
-from utils import fmt, first_json_object, safe_json_loads, slug
+try:
+    from .constants import (
+        CLASSIFY_QUERY_PROMPT,
+        CLASSIFY_SCHEMA_HINT,
+        PLANNER_PROMPT,
+    )
+    from .bb_types import Classification, Contract, Node, Plan, TestSpec
+    from .utils import fmt, first_json_object, safe_json_loads, slug
+except ImportError:  # pragma: no cover - fallback for script usage
+    from constants import (
+        CLASSIFY_QUERY_PROMPT,
+        CLASSIFY_SCHEMA_HINT,
+        PLANNER_PROMPT,
+    )  # type: ignore
+    from bb_types import Classification, Contract, Node, Plan, TestSpec  # type: ignore
+    from utils import fmt, first_json_object, safe_json_loads, slug  # type: ignore
 
 # Heuristics for classifier
 _DELIVERABLE = re.compile(r"\b(design|architecture|spec|contract|roadmap|benchmark|compare|trade[- ]?offs?|rfc|plan|protocol|implementation|experiment|evaluate)\b", re.I)
@@ -35,8 +48,7 @@ def classify_query(query: str) -> Classification:
 async def classify_query_llm(query: str, llm, *, timeout: float = 15.0) -> Classification:
     if llm is None:
         return classify_query(query)
-    schema_hint = '{ "kind":"Atomic|Hybrid|Composite","score":0..1,"rationale":"...","cues":{...} }'
-    prompt = f"SYSTEM: CLASSIFY\nReturn ONLY JSON.\nSchema: {schema_hint}\nTask: Classify scope/complexity.\nQUERY: {query}"
+    prompt = fmt(CLASSIFY_QUERY_PROMPT, schema=CLASSIFY_SCHEMA_HINT, query=query)
     try:
         raw = await llm.complete(prompt, temperature=0.0, timeout=timeout)
         data = safe_json_loads(first_json_object(raw) or "{}"); data = data or {}

--- a/backend/mvp/solver.py
+++ b/backend/mvp/solver.py
@@ -5,8 +5,20 @@ from __future__ import annotations
 
 from typing import Mapping, Optional
 
-from constants import ANALYSIS_NODE_PROMPT, ANSWER_NODE_PROMPT, EXAMPLES_NODE_PROMPT
-from bb_types import PlannerLLM, SolverResult
+try:
+    from .constants import (
+        ANALYSIS_NODE_PROMPT,
+        ANSWER_NODE_PROMPT,
+        EXAMPLES_NODE_PROMPT,
+    )
+    from .bb_types import PlannerLLM, SolverResult
+except ImportError:  # pragma: no cover - fallback for script usage
+    from constants import (
+        ANALYSIS_NODE_PROMPT,
+        ANSWER_NODE_PROMPT,
+        EXAMPLES_NODE_PROMPT,
+    )  # type: ignore
+    from bb_types import PlannerLLM, SolverResult  # type: ignore
 
 
 class EchoSolver:

--- a/backend/mvp/utils.py
+++ b/backend/mvp/utils.py
@@ -19,12 +19,20 @@ try:
 except Exception:  # pragma: no cover - optional dependency
     np = None  # type: ignore
 
-from config import (
-    GLOBAL_BURST_WINDOW_SEC,
-    GLOBAL_MAX_CONCURRENT,
-    GLOBAL_QPS,
-    KLINE_EMBED_DIM,
-)
+try:
+    from .config import (
+        GLOBAL_BURST_WINDOW_SEC,
+        GLOBAL_MAX_CONCURRENT,
+        GLOBAL_QPS,
+        KLINE_EMBED_DIM,
+    )
+except ImportError:  # pragma: no cover - fallback for script usage
+    from config import (
+        GLOBAL_BURST_WINDOW_SEC,
+        GLOBAL_MAX_CONCURRENT,
+        GLOBAL_QPS,
+        KLINE_EMBED_DIM,
+    )  # type: ignore
 
 # ------------------------------- Logging --------------------------------------
 
@@ -169,7 +177,10 @@ def dequantize(q: List[int]) -> List[float]:
 
 # ------------------------------ QA / Patching --------------------------------
 
-from bb_types import Contract, Issue, Patch, QAResult, TestSpec  # circular-safe
+try:
+    from .bb_types import Contract, Issue, Patch, QAResult, TestSpec  # circular-safe
+except ImportError:  # pragma: no cover - fallback for script usage
+    from bb_types import Contract, Issue, Patch, QAResult, TestSpec  # type: ignore
 
 
 def run_tests(content: str, contract: Contract) -> QAResult:


### PR DESCRIPTION
## Summary
- centralize classification and demo strings in `backend/mvp/constants.py`
- update MVP modules to import constants and dependencies defensively
- ensure demo and planner use shared prompt templates

## Testing
- `PYTHONPATH=. pytest backend/tests -q`
- `PYTHONPATH=. pytest -q` *(fails: existing logging/TLS tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8ec8dcdc8325973af9f8558cf58b